### PR TITLE
Fix empty error message by display error code as well

### DIFF
--- a/src/Service/OpenAI/Client.php
+++ b/src/Service/OpenAI/Client.php
@@ -49,7 +49,7 @@ class Client
         }
 
         if (isset($json['error'])) {
-            $msg = 'OpenAI Error: ' . $json['error']['message'];
+            $msg = 'OpenAI Error: ' . $json['error'] . '['.$json['code'].']';
             throw new \Exception($msg);
         }
 


### PR DESCRIPTION
Sometimes, like with the error code `invalid_api_key` there is no `message` in the JSON `error`. This PR simply adds the `code` so troubleshooting becomes easier.