### PR TITLE
Add sales channel option

### DIFF
--- a/src/Command/ProductGenerateCommand.php
+++ b/src/Command/ProductGenerateCommand.php
@@ -64,6 +64,7 @@ class ProductGenerateCommand extends Command implements ProductGeneratorInterfac
             ->addOption('count', null, InputOption::VALUE_REQUIRED, 'Number of products to generate')
             ->addOption('keywords', null, InputOption::VALUE_REQUIRED, 'Keywords to generate products for')
             ->addOption('category', null, InputOption::VALUE_REQUIRED, 'The name of your category in the Storefront to append the products to.')
+            ->addOption('saleschannel', null, InputOption::VALUE_REQUIRED, 'The name of your Storefront sales channel to add the products to.')
             ->addOption('images', null, InputOption::VALUE_REQUIRED, 'Indicates if images should be generated for the products.')
             ->addOption('images-size', null, InputOption::VALUE_REQUIRED, 'The width and height of product images in pixels. (wxh)');
     }
@@ -82,6 +83,7 @@ class ProductGenerateCommand extends Command implements ProductGeneratorInterfac
         $count = $input->getOption('count');
         $keyWords = $input->getOption('keywords');
         $category = $input->getOption('category');
+        $salesChannel = $input->getOption('saleschannel');
         $withImages = $input->getOption('images');
         $imgSize = $input->getOption('images-size');
 
@@ -101,6 +103,10 @@ class ProductGenerateCommand extends Command implements ProductGeneratorInterfac
             $category = '';
         }
 
+        if ($salesChannel === null) {
+            $salesChannel = '';
+        }
+
         if ($withImages === null) {
             $withImages = $this->configService->isProductImageEnabled();
         } else {
@@ -117,6 +123,12 @@ class ProductGenerateCommand extends Command implements ProductGeneratorInterfac
             $this->io->note('No category given. Products will be generated without a category.');
         } else {
             $this->io->note('Products will be generated for category: ' . $category);
+        }
+
+        if ($salesChannel === '') {
+            $this->io->note('No sales channel given. Products will be added to fisrt storefront sales channel.');
+        } else {
+            $this->io->note('Products will be added to sales channel: ' . $salesChannel);
         }
 
         if ($withImages) {
@@ -143,6 +155,7 @@ class ProductGenerateCommand extends Command implements ProductGeneratorInterfac
             $keyWords,
             $count,
             $category,
+            $salesChannel,
             $descriptionLength
         );
 

--- a/src/Repository/SalesChannelRepository.php
+++ b/src/Repository/SalesChannelRepository.php
@@ -40,4 +40,15 @@ class SalesChannelRepository
             ->search($criteria, Context::createDefaultContext())
             ->first();
     }
+
+    public function getByName(string $name): SalesChannelEntity
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('name', $name));
+        $criteria->setLimit(1);
+
+        return $this->repository
+            ->search($criteria, Context::createDefaultContext())
+            ->first();
+    }
 }

--- a/src/Service/Generator/ProductGenerator.php
+++ b/src/Service/Generator/ProductGenerator.php
@@ -114,11 +114,12 @@ class ProductGenerator
      * @param string $keywords
      * @param int $maxCount
      * @param string $category
+     * @param string $salesChannel
      * @param int $descriptionLength
      * @throws \JsonException
      * @return void
      */
-    public function generate(string $keywords, int $maxCount, string $category, int $descriptionLength)
+    public function generate(string $keywords, int $maxCount, string $category, string $salesChannel, int $descriptionLength)
     {
         $prompt = 'Create a list of demo products with these properties, separated values with ";". Only write down values and no property names ' . PHP_EOL;
         $prompt .= PHP_EOL;
@@ -197,6 +198,7 @@ class ProductGenerator
                     $name,
                     $number,
                     $category,
+                    $salesChannel,
                     $description,
                     $price,
                     $tmpImageFile,
@@ -220,6 +222,7 @@ class ProductGenerator
      * @param string $name
      * @param string $number
      * @param string $categoryName
+     * @param string $salesChannelName
      * @param string $description
      * @param float $price
      * @param string $image
@@ -227,14 +230,18 @@ class ProductGenerator
      * @param string $metaDescription
      * @return void
      */
-    private function createProduct(string $id, string $name, string $number, string $categoryName, string $description, float $price, string $image, string $ean, string $metaDescription): void
+    private function createProduct(string $id, string $name, string $number, string $categoryName, string $salesChannelName, string $description, float $price, string $image, string $ean, string $metaDescription): void
     {
         # just reuse the product one ;)
         $mediaId = $id;
         $visibilityID = $id;
         $coverId = $id;
 
-        $salesChannel = $this->repoSalesChannel->getStorefrontSalesChannel();
+        if (!empty($salesChannelName)) {
+            $salesChannel = $this->repoSalesChannel->getByName($salesChannelName);
+        } else {
+            $salesChannel = $this->repoSalesChannel->getStorefrontSalesChannel();
+        }
         $tax = $this->repoTaxes->getTaxEntity(19);
         $currency = $this->repoCurrency->getCurrencyEuro();
 


### PR DESCRIPTION
This PR adds a new option `saleschannel` for the product generate command. This is relevant for systems with multiple storefront sales channels. In combination with the category option the product will then show up in the right shop and category.

Thx for you stream with nevercodealone :-)